### PR TITLE
Automatically trigger the `sync-ref` workflow runs on pushes to `git/git`

### DIFF
--- a/GitGitGadget/gently.js
+++ b/GitGitGadget/gently.js
@@ -1,0 +1,7 @@
+module.exports = (fn, fallback) => {
+    try {
+        return fn()
+    } catch (e) {
+        return fallback
+    }
+}

--- a/GitGitGadget/get-installation-access-token.js
+++ b/GitGitGadget/get-installation-access-token.js
@@ -1,0 +1,14 @@
+const getInstallationAccessToken = async (context, installation_id) => {
+    const { gitHubAPIRequestAsApp } = require('./github-api-request-as-app')
+    const answer = await gitHubAPIRequestAsApp(
+        context,
+        'POST',
+        `/app/installations/${installation_id}/access_tokens`)
+    if (answer.error) throw answer.error
+    if (answer.token) return answer.token
+    throw new Error(`Unhandled response:\n${JSON.stringify(answer, null, 2)}`)
+}
+
+module.exports = {
+    getInstallationAccessToken
+}

--- a/GitGitGadget/get-installation-id-for-repo.js
+++ b/GitGitGadget/get-installation-id-for-repo.js
@@ -1,0 +1,14 @@
+const getInstallationIdForRepo = async (context, owner, repo) => {
+    const { gitHubAPIRequestAsApp } = require('./github-api-request-as-app')
+    const answer = await gitHubAPIRequestAsApp(
+        context,
+        'GET',
+        `/repos/${owner}/${repo}/installation`
+    )
+    if (answer.error) throw answer.error
+    return answer.id
+}
+
+module.exports = {
+    getInstallationIdForRepo
+}

--- a/GitGitGadget/github-api-request-as-app.js
+++ b/GitGitGadget/github-api-request-as-app.js
@@ -1,0 +1,47 @@
+const gitHubAPIRequestAsApp = async (context, requestMethod, requestPath, body) => {
+    const header = {
+        "alg": "RS256",
+        "typ": "JWT"
+    }
+
+    const now = Math.floor(new Date().getTime() / 1000)
+
+    const payload = {
+        // issued at time, 60 seconds in the past to allow for clock drift
+        iat: now - 60,
+        // JWT expiration time (10 minute maximum)
+        exp: now + (10 * 60),
+        // GitHub App's identifier
+        iss: process.env['GITHUB_APP_ID']
+    }
+
+    const toBase64 = (obj) => Buffer.from(JSON.stringify(obj), "utf-8").toString("base64url")
+    const headerAndPayload = `${toBase64(header)}.${toBase64(payload)}`
+
+    const privateKey = process.env['GITHUB_APP_PRIVATE_KEY'].replaceAll('\\n', '\n')
+
+    const crypto = require('crypto')
+    const signer = crypto.createSign("RSA-SHA256")
+    signer.update(headerAndPayload)
+    const signature = signer.sign({
+        key: privateKey
+    }, "base64url")
+
+    const token = `${headerAndPayload}.${signature}`
+
+    const { httpsRequest } = require('./https-request')
+    return await httpsRequest(
+        context,
+        null,
+        requestMethod,
+        requestPath,
+        body,
+        {
+            Authorization: `Bearer ${token}`,
+        }
+    )
+}
+
+module.exports = {
+    gitHubAPIRequestAsApp
+}

--- a/GitGitGadget/github-api-request.js
+++ b/GitGitGadget/github-api-request.js
@@ -1,0 +1,11 @@
+const gitHubAPIRequest = async (context, token, method, requestPath, payload) => {
+    const { httpsRequest } = require('./https-request')
+    const headers = token ? { Authorization: `Bearer ${token}` } : null
+    const answer = await httpsRequest(context, null, method, requestPath, payload, headers)
+    if (answer.error) throw answer.error
+    return answer
+}
+
+module.exports = {
+    gitHubAPIRequest
+}

--- a/GitGitGadget/https-request.js
+++ b/GitGitGadget/https-request.js
@@ -1,0 +1,88 @@
+const gently = require('./gently')
+
+const httpsRequest = async (context, hostname, method, requestPath, body, headers) => {
+    headers = {
+        'User-Agent': 'GitForWindowsHelper/0.0',
+        Accept: 'application/json',
+        ...headers || {}
+    }
+    if (body) {
+        if (typeof body === 'object') body = JSON.stringify(body)
+        headers['Content-Type'] = 'application/json'
+        headers['Content-Length'] = body.length
+    }
+    const options = {
+        port: 443,
+        hostname: hostname || 'api.github.com',
+        method: method || 'GET',
+        path: requestPath,
+        headers
+    }
+    return new Promise((resolve, reject) => {
+        try {
+            const https = require('https')
+            const req = https.request(options, res => {
+                res.on('error', e => reject(e))
+
+                if (res.statusCode === 204) resolve({
+                    statusCode: res.statusCode,
+                    statusMessage: res.statusMessage,
+                    headers: res.headers
+                })
+
+                const chunks = []
+                res.on('data', data => chunks.push(data))
+                res.on('end', () => {
+                    const json = Buffer.concat(chunks).toString('utf-8')
+                    if (res.statusCode > 299) {
+                        reject({
+                            statusCode: res.statusCode,
+                            statusMessage: res.statusMessage,
+                            requestMethod: options.method,
+                            requestPath: options.path,
+                            body: json,
+                            json: gently(() => JSON.parse(json))
+                        })
+                        return
+                    }
+                    try {
+                        resolve(JSON.parse(json))
+                    } catch (e) {
+                        reject(`Invalid JSON: ${json}`)
+                    }
+                })
+            })
+            req.on('error', err => reject(err))
+            if (body) req.write(body)
+            req.end()
+        } catch (e) {
+            reject(e)
+        }
+    })
+}
+
+const doesURLReturn404 = async url => {
+    const match = url.match(/^https:\/\/([^/]+?)(:\d+)?(\/.*)?$/)
+    if (!match) throw new Error(`Could not parse URL ${url}`)
+
+    const https = require('https')
+    const options = {
+        method: 'HEAD',
+        host: match[1],
+        port: Number.parseInt(match[2] || '443'),
+        path: match[3] || '/'
+    }
+    return new Promise((resolve, reject) => {
+        https.request(options, res => {
+            if (res.error) reject(res.error)
+            else if (res.statusCode === 404) resolve(true)
+            else if (res.statusCode === 200) resolve(false)
+            else reject(`Unexpected statusCode: ${res.statusCode}`)
+        }).end()
+    })
+}
+
+module.exports = {
+    httpsRequest,
+    doesURLReturn404
+}

--- a/GitGitGadget/trigger-azure-pipeline.js
+++ b/GitGitGadget/trigger-azure-pipeline.js
@@ -1,0 +1,48 @@
+const https = require('https');
+
+const triggerAzurePipeline = async (token, organization, project, buildDefinitionId, sourceBranch, parameters) => {
+    const auth = Buffer.from('PAT:' + token).toString('base64');
+    const headers = {
+        'Accept': 'application/json; api-version=5.0-preview.5; excludeUrls=true',
+        'Authorization': 'Basic ' + auth,
+    };
+    const json = JSON.stringify({
+        'definition': { 'id': buildDefinitionId },
+        'sourceBranch': sourceBranch,
+        'parameters': JSON.stringify(parameters),
+    });
+    headers['Content-Type'] = 'application/json';
+    headers['Content-Length'] = Buffer.byteLength(json);
+
+    const requestOptions = {
+        host: 'dev.azure.com',
+        port: '443',
+        path: `/${organization}/${project}/_apis/build/builds?ignoreWarnings=false&api-version=5.0-preview.5`,
+        method: 'POST',
+        headers: headers
+    };
+
+    return new Promise((resolve, reject) => {
+        const handleResponse = (res) => {
+            res.setEncoding('utf8');
+            var response = '';
+            res.on('data', (chunk) => {
+                response += chunk;
+            });
+            res.on('end', () => {
+                resolve(JSON.parse(response));
+            });
+            res.on('error', (err) => {
+                reject(err);
+            })
+        };
+
+        const request = https.request(requestOptions, handleResponse);
+        request.write(json);
+        request.end();
+    });
+}
+
+module.exports = {
+    triggerAzurePipeline
+}

--- a/GitGitGadget/trigger-workflow-dispatch.js
+++ b/GitGitGadget/trigger-workflow-dispatch.js
@@ -36,6 +36,14 @@ const waitForWorkflowRun = async (context, token, owner, repo, workflow_id, afte
 }
 
 const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id, ref, inputs) => {
+    if (token === undefined) {
+        const { getInstallationIdForRepo } = require('./get-installation-id-for-repo')
+        const installationID = await getInstallationIdForRepo(context, owner, repo)
+
+        const { getInstallationAccessToken } = require('./get-installation-access-token')
+        token = await getInstallationAccessToken(context, installationID)
+    }
+
     const { headers: { date } } = await gitHubAPIRequest(
         context,
         token,

--- a/GitGitGadget/trigger-workflow-dispatch.js
+++ b/GitGitGadget/trigger-workflow-dispatch.js
@@ -1,0 +1,54 @@
+const { gitHubAPIRequest } = require('./github-api-request')
+const { gitHubAPIRequestAsApp } = require('./github-api-request-as-app')
+
+const sleep = async (milliseconds) => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, milliseconds)
+    })
+}
+
+const getActorForToken = async (context, token) => {
+    try {
+        const { login } = await gitHubAPIRequest(context, token, 'GET', '/user')
+        return login
+    } catch (e) {
+        if (e.statusCode !== 403 || e.json?.message !== 'Resource not accessible by integration') throw e
+        const answer = await gitHubAPIRequestAsApp(context, 'GET', '/app')
+        return `${answer.slug}[bot]`
+    }
+}
+
+const waitForWorkflowRun = async (context, token, owner, repo, workflow_id, after, actor) => {
+    if (!actor) actor = await getActorForToken(context, token)
+    let counter = 0
+    for (;;) {
+        const res = await gitHubAPIRequest(
+            context,
+            token,
+            'GET',
+            `/repos/${owner}/${repo}/actions/runs?actor=${actor}&event=workflow_dispatch&created=>${after}`
+        )
+        const filtered = res.workflow_runs.filter(e => e.path === `.github/workflows/${workflow_id}`)
+        if (filtered.length > 0) return filtered
+        if (counter++ > 30) throw new Error(`Times out waiting for workflow?`)
+        await sleep(1000)
+    }
+}
+
+const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id, ref, inputs) => {
+    const { headers: { date } } = await gitHubAPIRequest(
+        context,
+        token,
+        'POST',
+        `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`,
+        { ref, inputs }
+    )
+
+    const runs = await waitForWorkflowRun(context, token, owner, repo, workflow_id, new Date(date).toISOString())
+    return runs[0]
+}
+
+module.exports = {
+    triggerWorkflowDispatch,
+    waitForWorkflowRun
+}

--- a/GitGitGadget/validate-github-webhook.js
+++ b/GitGitGadget/validate-github-webhook.js
@@ -1,0 +1,27 @@
+const crypto = require('crypto');
+
+const validateGitHubWebHook = (context) => {
+    const secret = process.env['GITHUB_WEBHOOK_SECRET'];
+    if (!secret) {
+        throw new Error('Webhook secret not configured');
+    }
+    if (context.req.headers['content-type'] !== 'application/json') {
+        throw new Error('Unexpected content type: ' + context.req.headers['content-type']);
+    }
+    const signature = context.req.headers['x-hub-signature-256'];
+    if (!signature) {
+        throw new Error('Missing X-Hub-Signature');
+    }
+    const sha256 = signature.match(/^sha256=(.*)/);
+    if (!sha256) {
+        throw new Error('Unexpected X-Hub-Signature format: ' + signature);
+    }
+    const computed = crypto.createHmac('sha256', secret).update(context.req.rawBody).digest('hex');
+    if (sha256[1] !== computed) {
+        throw new Error('Incorrect X-Hub-Signature');
+    }
+}
+
+module.exports = {
+    validateGitHubWebHook
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Instead of pushing the code to Azure all the time, waiting until it is deployed,
 
 To this end, [install the Azure Functions Core Tools (for performance, use Linux)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Clinux%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools, e.g. via [WSL](https://learn.microsoft.com/en-us/windows/wsl/)).
 
-Then, configure [the `GITHUB_WEBHOOK_SECRET` variable](#some-environment-variables) locally, via [a `local.settings.json` file](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local#local-settings-file). The contents would look like this:
+Then, configure [the `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY` and `GITHUB_WEBHOOK_SECRET` variables](#some-environment-variables) locally, via [a `local.settings.json` file](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local#local-settings-file). The contents would look like this:
 
 ```json
 {
@@ -29,6 +29,8 @@ Then, configure [the `GITHUB_WEBHOOK_SECRET` variable](#some-environment-variabl
   "Values": {
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AzureWebJobsStorage": "<storage-key>",
+    "GITHUB_APP_ID": "<app-id>",
+    "GITHUB_APP_PRIVATE_KEY": "<private-key>",
     "GITHUB_WEBHOOK_SECRET": "<webhook-secret>"
   },
   "Host": {
@@ -60,6 +62,8 @@ After the deployment succeeded, in the "Overview" tab, there is a "Get publish p
 A few environment variables will have to be configured for use with the Azure Function. This can be done on the "Configuration" tab, which is in the "Settings" group.
 
 Concretely, the environment variables `GITHUB_WEBHOOK_SECRET` and `GITGITGADGET_TRIGGER_TOKEN` (a Personal Access Token to trigger the Azure Pipelines) need to be set. For the first, a generated random string was used. The second one was [created](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#create-a-pat) scoped to the Azure DevOps project `gitgitgadget` with the Build (read & execute) permissions.
+
+Also, the `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` variables are needed in order to trigger GitHub workflow runs. These were obtained as part of registering the GitHub App.
 
 ### The repository
 

--- a/__tests__/get-installation-access-token.test.js
+++ b/__tests__/get-installation-access-token.test.js
@@ -1,0 +1,32 @@
+const mockHTTPSRequest = jest.fn(async (context, hostname, method, requestPath, body, headers) => {
+    // We're not validating the authorization, just validating that there is one
+    expect(headers.Authorization).toMatch(/Bearer [-.0-9A-Za-z_]{40,}/)
+
+    if (requestPath === '/repos/hello/world/installation') return { id: 17 }
+    if (requestPath === '/app/installations/17/access_tokens') return { token: 'i-can-haz-access-token' }
+    throw new Error(`Unexpected requestPath: '${requestPath}'`)
+})
+jest.mock('../GitGitGadget/https-request', () => { return { httpsRequest: mockHTTPSRequest } })
+const { getInstallationIdForRepo } = require('../GitGitGadget/get-installation-id-for-repo')
+const { getInstallationAccessToken } = require('../GitGitGadget/get-installation-access-token')
+
+const { generateKeyPairSync } = require('crypto')
+
+const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem'
+    },
+    privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+    }
+})
+process.env['GITHUB_APP_PRIVATE_KEY'] = privateKey
+
+test('get an installation access token', async () => {
+    const context = {}
+    const installationID = await getInstallationIdForRepo(context, 'hello', 'world')
+    expect(await getInstallationAccessToken(context, installationID)).toEqual('i-can-haz-access-token')
+})

--- a/__tests__/trigger-workflow-dispatch.test.js
+++ b/__tests__/trigger-workflow-dispatch.test.js
@@ -1,0 +1,47 @@
+const mockHTTPSRequest = jest.fn(async (_context, _hostname, method, requestPath) => {
+    if (method === 'POST' && requestPath === '/repos/hello/world/actions/workflows/the-workflow.yml/dispatches') {
+        return {
+            headers: {
+                date: '2023-01-23T01:23:45Z'
+            }
+        }
+    }
+    if (method === 'GET' && requestPath === '/user') return { login: 'the actor' }
+    if (method === 'GET' && requestPath === '/repos/hello/world/actions/runs?actor=the actor&event=workflow_dispatch&created=>2023-01-23T01:23:45.000Z') {
+        return {
+            workflow_runs: [
+                { path: 'not this one.yml' },
+                { path: '.github/workflows/the-workflow.yml', breadcrumb: true },
+                { path: 'neither this one.yml' }
+            ]
+        }
+    }
+    throw new Error(`Unexpected requestPath: ${method} '${requestPath}'`)
+})
+jest.mock('../GitGitGadget/https-request', () => { return { httpsRequest: mockHTTPSRequest } })
+
+const { triggerWorkflowDispatch } = require('../GitGitGadget/trigger-workflow-dispatch')
+
+const { generateKeyPairSync } = require('crypto')
+
+const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: {
+        type: 'spki',
+        format: 'pem'
+    },
+    privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+    }
+})
+process.env['GITHUB_APP_PRIVATE_KEY'] = privateKey
+
+test('trigger a workflow_dispatch event and wait for workflow run', async () => {
+    const context = {}
+    const run = await triggerWorkflowDispatch(context, 'my-token', 'hello', 'world', 'the-workflow.yml', 'HEAD', { abc: 123 })
+    expect(run).toEqual({
+        path: '.github/workflows/the-workflow.yml',
+        breadcrumb: true
+    })
+})


### PR DESCRIPTION
The `gitgitgadget-git` GitHub App is set up to deliver `push` webhook events. We might just as well put those events to good use by triggering the GitHub workflow whose responsibility it is to synchronize the `git/git` branches to `gitgitgadget/git`.