### PR TITLE
Move to a new org for GitGitGadget's manually-triggered workflows

### DIFF
--- a/GitGitGadget/index.js
+++ b/GitGitGadget/index.js
@@ -64,7 +64,7 @@ module.exports = async (context, req) => {
                 const run = await triggerWorkflowDispatch(
                     context,
                     undefined,
-                    'gitgitgadget',
+                    'gitgitgadget-workflows',
                     'gitgitgadget-workflows',
                     'sync-ref.yml',
                     'main', {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,5 +1,5 @@
 const mockTriggerWorkflowDispatch = jest.fn(async (_context, _token, owner, repo, workflow_id, ref, inputs) => {
-    expect(`${owner}/${repo}`).toEqual('gitgitgadget/gitgitgadget-workflows')
+    expect(`${owner}/${repo}`).toEqual('gitgitgadget-workflows/gitgitgadget-workflows')
     expect(workflow_id).toEqual('sync-ref.yml')
     expect(ref).toEqual('main')
     expect(inputs).toEqual({ ref: 'refs/heads/next' })
@@ -203,7 +203,7 @@ testWebhookPayload('react to `next` being pushed to git/git', 'push', {
     expect(mockTriggerWorkflowDispatch.mock.calls[0]).toEqual([
         context,
         undefined,
-        'gitgitgadget',
+        'gitgitgadget-workflows',
         'gitgitgadget-workflows',
         'sync-ref.yml',
         'main', {


### PR DESCRIPTION
The Git maintainer frequently pushes out dozens of branches at the same time. Every of those branches triggers their own CI run, spawning almost 50 jobs, with an overall runtime of over 8h (!) which would amortize to a shorter wall-clock time if only the concurrency limit of 20 parallel jobs was not depleted so efficiently.

These concurrency limits are org-wide on GitHub. That is, when dozens of workflow runs are partially running, partially queued up, in `gitgitgadget/git`, all new workflow runs in
`gitgitgadget/gitgitgadget-workflows` are queued and will have to wait their turn.

In combination, this leads to a frequent starvation of GitHub Actions resources, which means: even short tasks (like the `sync-ref` workflow) won't run for several hours in such situations.

To remedy that, I forked the `gitgitgadget-workflows` repository into a new org: `gitgitgadget-workflows. That way, the workflows like `sync-ref` do not have to wait for CI/PR runs to finish in `gitgitgadget/git`.

This PR adjusts GitGitGadget's GitHub App to trigger the `sync-ref` workflow in that org.

My long-term plan is to rename the forked repository, move the repository from `gitgitgadget`, and then delete the (renamed) fork. This somewhat complex process is necessary so as not to disrupt GitGitGadget while this here PR is not yet merged.