### PR TITLE
Allow deploying from forks, to support projects other than Git

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -2,3 +2,6 @@
 /*.md
 /host.json
 /local.settings.json
+/package.json
+/package-lock.json
+/jest.config.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,61 @@
 name: Deploy to Azure
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
+      - '.funcignore'
       - '.github/workflows/deploy.yml'
       - 'GitGitGadget/**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
-    if: github.event.repository.fork == false
+    if: github.event.repository.fork == false || vars.DEPLOY_WITH_WORKFLOWS != ''
     environment: deploy-to-azure
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: parse DEPLOY_WITH_WORKFLOWS
+        if: vars.DEPLOY_WITH_WORKFLOWS != '' && contains(vars.DEPLOY_WITH_WORKFLOWS, '/')
+        id: parsed
+        env:
+          WORKFLOWS_REPO: '${{ vars.DEPLOY_WITH_WORKFLOWS }}'
+        run: |
+          echo "owner=${WORKFLOWS_REPO%%/*}" >>$GITHUB_OUTPUT &&
+          echo "name=${WORKFLOWS_REPO#*/}" >>$GITHUB_OUTPUT
+      - name: retrieve `vars.CONFIG` from workflows repo
+        if: vars.DEPLOY_WITH_WORKFLOWS != ''
+        env:
+          WORKFLOWS_REPO: '${{ vars.DEPLOY_WITH_WORKFLOWS }}'
+          GH_TOKEN: ${{ steps.workflows-repo-token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          set -x &&
+          if ! curl -fLO https://github.com/"$WORKFLOWS_REPO"/raw/config/gitgitgadget-config.json
+          then
+            echo "::error::Could not retrieve 'gitgitgadget-config.json' from the 'config' branch of $WORKFLOWS_REPO"
+            exit 1
+          fi &&
+          jq '. + {
+            "workflowsRepo": {
+              "owner": "${{ steps.parsed.outputs.owner }}",
+              "name": "${{ steps.parsed.outputs.name }}"
+            }
+          }' <gitgitgadget-config.json >GitGitGadget/gitgitgadget-config.json &&
+          echo "Using the following configuration:" &&
+          cat GitGitGadget/gitgitgadget-config.json
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - uses: Azure/functions-action@v1
         with:
-          app-name: GitGitGadget
-          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+          app-name: ${{ secrets.AZURE_FUNCTION_NAME || 'GitGitGadget' }}
           respect-funcignore: true

--- a/GitGitGadget/gitgitgadget-config.json
+++ b/GitGitGadget/gitgitgadget-config.json
@@ -1,0 +1,78 @@
+{
+  "repo": {
+    "name": "git",
+    "owner": "gitgitgadget",
+    "baseOwner": "git",
+    "testOwner": "dscho",
+    "owners": [
+      "gitgitgadget",
+      "git",
+      "dscho"
+    ],
+    "branches": [
+      "maint",
+      "seen"
+    ],
+    "closingBranches": [
+      "maint",
+      "master"
+    ],
+    "trackingBranches": [
+      "maint",
+      "seen",
+      "master",
+      "next"
+    ],
+    "maintainerBranch": "gitster",
+    "host": "github.com"
+  },
+  "mailrepo": {
+    "name": "git",
+    "owner": "gitgitgadget",
+    "branch": "master",
+    "host": "lore.kernel.org",
+    "url": "https://lore.kernel.org/git/",
+    "public_inbox_epoch": 1,
+    "mirrorURL": "https://github.com/gitgitgadget/git-mailing-list-mirror",
+    "mirrorRef": "refs/heads/lore-1",
+    "descriptiveName": "lore.kernel/git"
+  },
+  "mail": {
+    "author": "GitGitGadget",
+    "sender": "GitGitGadget",
+    "smtpUser": "gitgitgadget@gmail.com",
+    "smtpHost": "smtp.gmail.com"
+  },
+  "app": {
+    "appID": 12836,
+    "installationID": 195971,
+    "name": "gitgitgadget",
+    "displayName": "GitGitGadget",
+    "altname": "gitgitgadget-git"
+  },
+  "lint": {
+    "maxCommitsIgnore": [
+      "https://github.com/gitgitgadget/git/pull/923"
+    ],
+    "maxCommits": 30
+  },
+  "user": {
+    "allowUserAsLogin": false
+  },
+  "syncUpstreamBranches": [
+    {
+      "sourceRepo": "gitster/git",
+      "targetRepo": "gitgitgadget/git",
+      "sourceRefRegex": "^refs/heads/(maint-\\d|[a-z][a-z]/)"
+    },
+    {
+      "sourceRepo": "j6t/git-gui",
+      "targetRepo": "gitgitgadget/git",
+      "targetRefNamespace": "git-gui/"
+    }
+  ],
+  "workflowsRepo": {
+    "owner": "gitgitgadget-workflows",
+    "name": "gitgitgadget-workflows"
+  }
+}

--- a/GitGitGadget/index.js
+++ b/GitGitGadget/index.js
@@ -25,14 +25,10 @@ module.exports = async (context, req) => {
     }
 
     try {
-        /*
-         * For various reasons, the GitGitGadget GitHub App can be installed
-         * on any random repository. However, GitGitGadget only wants to support
-         * the `gitgitgadget/git` and the `git/git` repository (with the
-         * `dscho/git` one thrown in for debugging purposes).
-         */
-        const orgs = ['gitgitgadget', 'git', 'dscho']
-        const a = [context, undefined, 'gitgitgadget-workflows', 'gitgitgadget-workflows']
+        const { readFileSync } = require('fs')
+        const config = JSON.parse(readFileSync(`${__dirname}/gitgitgadget-config.json`))
+        const orgs = config.repo.owners
+        const a = [context, undefined, config.workflowsRepo.owner, config.workflowsRepo.name]
 
         const eventType = context.req.headers['x-github-event'];
         context.log(`Got eventType: ${eventType}`);
@@ -40,7 +36,7 @@ module.exports = async (context, req) => {
         if (!orgs.includes(repositoryOwner)) {
             context.res = {
                 status: 403,
-                body: 'Refusing to work on a repository other than gitgitgadget/git or git/git'
+                body: `Refusing to work on any repository outside of ${orgs.join(', ')}`,
             };
         } else if (eventType === 'pull_request') {
             if (req.body.action !== 'opened' && req.body.action !== 'synchronize') {
@@ -58,9 +54,9 @@ module.exports = async (context, req) => {
                 body: `Ignored event type: ${eventType}`,
             };
         } else if (eventType === 'push') {
-            if (req.body.repository.full_name ==='gitgitgadget/git-mailing-list-mirror') {
+            if (config.mailrepo.mirrorURL === `https://github.com/${req.body.repository.full_name}`) {
                 context.res = { body: `push(${req.body.ref} in ${req.body.repository.full_name}): ` }
-                if (req.body.ref === 'refs/heads/lore-1') {
+                if (req.body.ref === config.mailrepo.mirrorRef) {
                     const queued = await listWorkflowRuns(...a, 'handle-new-mails.yml', 'queued')
                     if (queued.length) {
                         context.res.body += [
@@ -72,7 +68,7 @@ module.exports = async (context, req) => {
                         context.res.body += `triggered ${run.html_url}`
                     }
                 } else context.res.body += `Ignoring non-default branches`
-            } else if (req.body.repository.full_name !== 'git/git') {
+            } else if (req.body.repository.full_name !== `${config.repo.baseOwner}/${config.repo.name}`) {
                 context.res = { body: `Ignoring pushes to ${req.body.repository.full_name}` }
             } else {
                 const run = await triggerWorkflowDispatch(
@@ -83,7 +79,7 @@ module.exports = async (context, req) => {
                     }
                 )
                 const extra = []
-                if (req.body.ref === 'refs/heads/seen') {
+                if (config.repo.branches.map((name) => `refs/heads/${name}`).includes(req.body.ref)) {
                     for (const workflow of ['update-prs.yml', 'update-mail-to-commit-notes.yml']) {
                         if ((await listWorkflowRuns(...a, workflow, 'main', 'queued')).length === 0) {
                             const run = await triggerWorkflowDispatch(...a, workflow, 'main')
@@ -102,7 +98,7 @@ module.exports = async (context, req) => {
             }
 
             /* GitGitGadget works on dscho/git only for testing */
-            if (repositoryOwner === 'dscho' && comment.user.login !== 'dscho') {
+            if (repositoryOwner === config.repo.testOwner && comment.user.login !== config.repo.testOwner) {
                 throw new Error(`Ignoring comment from ${comment.user.login}`);
             }
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -162,7 +162,7 @@ testIssueComment('/test', async (context) => {
 testIssueComment('/verify-repository', 'nope', (context) => {
     expect(context.done).not.toHaveBeenCalled()
     expect(context.res).toEqual({
-        body: 'Refusing to work on a repository other than gitgitgadget/git or git/git',
+        body: 'Refusing to work on any repository outside of gitgitgadget, git, dscho',
         'status': 403,
     })
     expect(mockRequest.write).not.toHaveBeenCalled()


### PR DESCRIPTION
This is the culmination of the huge journey that started with the big chunk of work ending in #4, evacuating GitGitGadget from Azure Pipelines.

There are still a couple of PRs that need to be merged before this here PR can be merged:
- https://github.com/gitgitgadget/gitgitgadget/pull/1991
- https://github.com/gitgitgadget/gitgitgadget/pull/2029
- https://github.com/gitgitgadget/gitgitgadget/pull/2030
- https://github.com/gitgitgadget/gitgitgadget/pull/1995
- https://github.com/gitgitgadget/gitgitgadget-workflows/pull/13
- https://github.com/gitgitgadget/gitgitgadget-workflows/pull/14