### PR TITLE
Allow for more clock drift when generating the JWT

### DIFF
--- a/GitGitGadget/github-api-request-as-app.js
+++ b/GitGitGadget/github-api-request-as-app.js
@@ -9,8 +9,8 @@ const gitHubAPIRequestAsApp = async (context, requestMethod, requestPath, body) 
     const payload = {
         // issued at time, 60 seconds in the past to allow for clock drift
         iat: now - 60,
-        // JWT expiration time (10 minute maximum)
-        exp: now + (10 * 60),
+        // JWT expiration time (10 minute maximum, use 9 to allow for clock drift)
+        exp: now + (9 * 60),
         // GitHub App's identifier
         iss: process.env['GITHUB_APP_ID']
     }

--- a/__tests__/trigger-workflow-dispatch.test.js
+++ b/__tests__/trigger-workflow-dispatch.test.js
@@ -7,7 +7,7 @@ const mockHTTPSRequest = jest.fn(async (_context, _hostname, method, requestPath
         }
     }
     if (method === 'GET' && requestPath === '/user') return { login: 'the actor' }
-    if (method === 'GET' && requestPath === '/repos/hello/world/actions/runs?actor=the actor&event=workflow_dispatch&created>=2023-01-23T01:23:45.000Z') {
+    if (method === 'GET' && requestPath === '/repos/hello/world/actions/runs?actor=the actor&event=workflow_dispatch&created=2023-01-23T01:23:45.000Z..*') {
         return {
             workflow_runs: [
                 { path: 'not this one.yml' },


### PR DESCRIPTION
For the rationale, the diff, and the symptom please see the commit message; this is a one-line preventive port, not a fix for an observed failure here. The same change has been running in `git-for-windows/gfw-helper-github-app` since git-for-windows/gfw-helper-github-app#49 (merged November 2023) and is being applied in parallel to the third descendant of the same file in git-for-windows/git-for-windows-automation#185.
