### PR TITLE
Use smarter way to obtain the exact run upon workflow dispatches

### DIFF
--- a/GitGitGadget/trigger-workflow-dispatch.js
+++ b/GitGitGadget/trigger-workflow-dispatch.js
@@ -44,14 +44,17 @@ const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id,
         token = await getInstallationAccessToken(context, installationID)
     }
 
-    const { headers: { date } } = await gitHubAPIRequest(
+    const response = await gitHubAPIRequest(
         context,
         token,
         'POST',
         `/repos/${owner}/${repo}/actions/workflows/${workflow_id}/dispatches`,
-        { ref, inputs }
+        { ref, inputs, return_run_details: true }
     )
 
+    if (response.workflow_run_id) return response
+
+    const date = response.headers?.date || new Date().toISOString()
     // Avoid missing the run if its timestamp is slightly earlier than the response.
     const after = new Date(Date.parse(date) - 5000).toISOString()
     const runs = await waitForWorkflowRun(context, token, owner, repo, workflow_id, after)

--- a/GitGitGadget/trigger-workflow-dispatch.js
+++ b/GitGitGadget/trigger-workflow-dispatch.js
@@ -52,7 +52,9 @@ const triggerWorkflowDispatch = async (context, token, owner, repo, workflow_id,
         { ref, inputs }
     )
 
-    const runs = await waitForWorkflowRun(context, token, owner, repo, workflow_id, new Date(date).toISOString())
+    // Avoid missing the run if its timestamp is slightly earlier than the response.
+    const after = new Date(Date.parse(date) - 5000).toISOString()
+    const runs = await waitForWorkflowRun(context, token, owner, repo, workflow_id, after)
     return runs[0]
 }
 

--- a/__tests__/trigger-workflow-dispatch.test.js
+++ b/__tests__/trigger-workflow-dispatch.test.js
@@ -1,4 +1,11 @@
 const mockHTTPSRequest = jest.fn(async (_context, _hostname, method, requestPath) => {
+    if (method === 'POST' && requestPath === '/repos/hello/world/actions/workflows/run-details.yml/dispatches') {
+        return {
+            workflow_run_id: 12345,
+            run_url: 'https://api.github.com/repos/hello/world/actions/runs/12345',
+            html_url: 'https://github.com/hello/world/actions/runs/12345'
+        }
+    }
     if (method === 'POST' && requestPath === '/repos/hello/world/actions/workflows/the-workflow.yml/dispatches') {
         return {
             headers: {
@@ -45,12 +52,35 @@ const { privateKey } = generateKeyPairSync('rsa', {
 })
 process.env['GITHUB_APP_PRIVATE_KEY'] = privateKey
 
-test('trigger a workflow_dispatch event and wait for workflow run', async () => {
+beforeEach(() => mockHTTPSRequest.mockClear())
+
+test('use workflow run details returned by the dispatch', async () => {
+    const context = {}
+    const run = await triggerWorkflowDispatch(context, 'my-token', 'hello', 'world', 'run-details.yml', 'HEAD', { abc: 123 })
+    expect(run).toEqual({
+        workflow_run_id: 12345,
+        run_url: 'https://api.github.com/repos/hello/world/actions/runs/12345',
+        html_url: 'https://github.com/hello/world/actions/runs/12345'
+    })
+    expect(mockHTTPSRequest).toHaveBeenCalledTimes(1)
+    expect(mockHTTPSRequest.mock.calls[0][4]).toEqual({
+        ref: 'HEAD',
+        inputs: { abc: 123 },
+        return_run_details: true
+    })
+})
+
+test('fall back to waiting for the workflow run', async () => {
     const context = {}
     const run = await triggerWorkflowDispatch(context, 'my-token', 'hello', 'world', 'the-workflow.yml', 'HEAD', { abc: 123 })
     expect(run).toEqual({
         path: '.github/workflows/the-workflow.yml',
         breadcrumb: true
+    })
+    expect(mockHTTPSRequest.mock.calls[0][4]).toEqual({
+        ref: 'HEAD',
+        inputs: { abc: 123 },
+        return_run_details: true
     })
 })
 

--- a/__tests__/trigger-workflow-dispatch.test.js
+++ b/__tests__/trigger-workflow-dispatch.test.js
@@ -7,7 +7,7 @@ const mockHTTPSRequest = jest.fn(async (_context, _hostname, method, requestPath
         }
     }
     if (method === 'GET' && requestPath === '/user') return { login: 'the actor' }
-    if (method === 'GET' && requestPath === '/repos/hello/world/actions/runs?actor=the actor&event=workflow_dispatch&created=2023-01-23T01:23:45.000Z..*') {
+    if (method === 'GET' && requestPath === '/repos/hello/world/actions/runs?actor=the actor&event=workflow_dispatch&created=2023-01-23T01:23:40.000Z..*') {
         return {
             workflow_runs: [
                 { path: 'not this one.yml' },


### PR DESCRIPTION
Previously, when we triggered runs via `workflow_dispatch`, we had to poll workflow runs to know which run was triggered. That fragile strategy is no longer necessary.

This is a companion of git-for-windows/gfw-helper-github-app#197.